### PR TITLE
Improve unique name function

### DIFF
--- a/config-connector-transform/main.py
+++ b/config-connector-transform/main.py
@@ -233,10 +233,14 @@ def ensure_unique_name(pulumi_resource):
     if multiple resources have the same name due to
     https://github.com/pulumi/pulumi/issues/6032"""
 
-    for resource in resources:
-        if 'name' in resource and 'name' in pulumi_resource and resource['name'] == pulumi_resource['name']:
-            pulumi_resource['name'] += "-1"
-            return
+    base_name = pulumi_resource["name"]
+    counter = 1
+
+    while any(
+        resource.get("name") == pulumi_resource["name"] for resource in resources
+    ):
+        pulumi_resource["name"] = f"{base_name}-{counter}"
+        counter += 1
 
 
 for doc in docs:


### PR DESCRIPTION
I tested the original renaming function in a scenario where I'd copied an item in the bulk export from the `config-connector` CLI tool a couple times, simulating more than two items having the same name. In this case, the original script will create many resources with the same name, e.g.
```
unique-name
unique-name-1
unique-name-1
unique-name-1
```
when the expected output is
```
unique-name
unique-name-1
unique-name-2
unique-name-3
```

This PR addresses that.